### PR TITLE
Make speed sensors support long-term statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
-# Hass Amplifi 2.0.0
+# Hass Amplifi 2.0.5
 
-**BREAKING CHANGE**
- - 2.0.0 now uses device_tracker instead of sensor for wifi presence
 
 A sensor hass integration that allows you to monitor devices connected to Amplifi on Wifi (LAN ports in progress).
+This is a fork of the original repo by @puttyman. This repo is largely for my own use but may receive more frequent support that the original repo.
 
 You can use this addon to perform the following automations:
-- As a presense sensor (when your mobile connects to wifi)
+- As a presense sensor (when your mobile connects to wifi, or to a specific AP/Mesh device)
 - Internet bandwidth usage monitor (amplifi reports data transfers on the WAN port). This integration will add 2 sensors.
 - When your TV is on/off (monitoring its wifi traffic)
 - Security (Create alerts for unknown devices connected to your wifi)
@@ -21,7 +20,7 @@ You can use this addon to perform the following automations:
 ### Install with HACS (recomended)
 
 Do you you have [HACS](https://community.home-assistant.io/t/custom-component-hacs) installed? Once you have HACS.
-- Add `puttyman/hass-amplifi` as a custom repository
+- Add `hawksj/hass-amplifi` as a custom repository
 - Click on th **Install** button for Hass Amplifi
 
 ### Install manually

--- a/custom_components/amplifi/coordinator.py
+++ b/custom_components/amplifi/coordinator.py
@@ -72,8 +72,8 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
                         ]:
                             device_info = raw_wifi_devices[access_point][wifi_band][
                                 network_type
-                            device_info["connected_to"] = access_point
                             ][macAddr]
+                            device_info["connected_to"] = access_point
                             wifi_devices[macAddr] = device_info
 
         self._wifi_devices = wifi_devices

--- a/custom_components/amplifi/coordinator.py
+++ b/custom_components/amplifi/coordinator.py
@@ -72,6 +72,7 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
                         ]:
                             device_info = raw_wifi_devices[access_point][wifi_band][
                                 network_type
+                            device_info["connected_to"] = access_point
                             ][macAddr]
                             wifi_devices[macAddr] = device_info
 

--- a/custom_components/amplifi/coordinator.py
+++ b/custom_components/amplifi/coordinator.py
@@ -73,7 +73,6 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
                             device_info = raw_wifi_devices[access_point][wifi_band][
                                 network_type
                             ][macAddr]
-                            device_info["connected_to"] = access_point
                             wifi_devices[macAddr] = device_info
 
         self._wifi_devices = wifi_devices

--- a/custom_components/amplifi/coordinator.py
+++ b/custom_components/amplifi/coordinator.py
@@ -73,6 +73,7 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
                             device_info = raw_wifi_devices[access_point][wifi_band][
                                 network_type
                             ][macAddr]
+                            device_info["connected_to"] = access_point
                             wifi_devices[macAddr] = device_info
 
         self._wifi_devices = wifi_devices

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -150,7 +150,6 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         """Return if the entity should be enabled when first added to the entity registry."""
         return True
 
-
     def update(self):
         _LOGGER.debug(f"entity={self.unique_id} update() was called")
         self._handle_coordinator_update()

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -137,11 +137,6 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
             return {**self._data, "last_seen": datetime.now().isoformat()}
         return {}
 
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        return True
-
     def update(self):
         _LOGGER.debug(f"entity={self.unique_id} update() was called")
         self._handle_coordinator_update()

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -145,6 +145,12 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
             return {**self._data, "last_seen": datetime.now().isoformat()}
         return {}
 
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return True
+
+
     def update(self):
         _LOGGER.debug(f"entity={self.unique_id} update() was called")
         self._handle_coordinator_update()

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -131,14 +131,6 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         return None
 
     @property
-    def connected_to(self):
-        """Return mac address of the AP this device is connected to."""
-        if "connected_to" in self._data:
-            return self._data["connected_to"]
-
-        return None
-
-    @property
     def extra_state_attributes(self):
         """Return extra attributes."""
         if self.coordinator.last_update_success and self._data is not None:

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -137,6 +137,11 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
             return {**self._data, "last_seen": datetime.now().isoformat()}
         return {}
 
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return True
+
     def update(self):
         _LOGGER.debug(f"entity={self.unique_id} update() was called")
         self._handle_coordinator_update()

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -131,6 +131,14 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         return None
 
     @property
+    def connected_to(self):
+        """Return mac address of the AP this device is connected to."""
+        if "connected_to" in self._data:
+            return self._data["connected_to"]
+
+        return None
+        
+    @property
     def extra_state_attributes(self):
         """Return extra attributes."""
         if self.coordinator.last_update_success and self._data is not None:

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -86,7 +86,7 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         elif self._data is not None and "Address" in self._data:
             self._name = f"{DOMAIN}_{self._data['Address']}"
         else:
-            self._name = self.unique_id
+            self._name = f"{DOMAIN}_{self.unique_id}"
 
         self._name = re.sub("[^0-9a-zA-Z]+", "_", self._name).lower()
 

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -131,8 +131,8 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         return None
 
     @property
-    def hostname(self):
-        """Return hostname of the device."""
+    def connected_to(self):
+        """Return mac address of the AP this device is connected to."""
         if "connected_to" in self._data:
             return self._data["connected_to"]
 

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -131,6 +131,14 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         return None
 
     @property
+    def hostname(self):
+        """Return hostname of the device."""
+        if "connected_to" in self._data:
+            return self._data["connected_to"]
+
+        return None
+
+    @property
     def extra_state_attributes(self):
         """Return extra attributes."""
         if self.coordinator.last_update_success and self._data is not None:

--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -2,15 +2,16 @@
   "domain": "amplifi",
   "name": "Amplifi",
   "config_flow": true,
-  "documentation": "https://github.com/puttyman/hass-amplifi",
-  "issue_tracker": "https://github.com/puttyman/hass-amplifi/issues",
+  "documentation": "https://github.com/hawksj/hass-amplifi",
+  "issue_tracker": "https://github.com/hawksj/hass-amplifi/issues",
   "requirements": [],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
   "codeowners": [
-    "@puttyman"
+    "@puttyman",
+    "@hawksj"
   ],
   "version": "2.0.5"
 }

--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
     "@puttyman"
   ],
-  "version": "2.0.3"
+  "version": "2.0.4"
 }

--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
     "@puttyman"
   ],
-  "version": "2.0.3"
+  "version": "2.0.5"
 }

--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
     "@puttyman"
   ],
-  "version": "2.0.4"
+  "version": "2.0.3"
 }

--- a/custom_components/amplifi/sensor.py
+++ b/custom_components/amplifi/sensor.py
@@ -15,7 +15,8 @@ from .const import DOMAIN, COORDINATOR, COORDINATOR_LISTENER, ENTITIES
 
 _LOGGER = logging.getLogger(__name__)
 WAN_SPEED_SENSOR_TYPES = ["download", "upload"]
-
+sensordeviceclass = SensorDeviceClass.DATA_RATE
+sensorstateclass = SensorStateClass.MEASUREMENT
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add sensors for passed config_entry in HA."""
@@ -50,8 +51,8 @@ class AmplifiWanSpeedSensor(CoordinatorEntity, SensorEntity):
         self.config_entry = config_entry
         self._speed_sensor_type = speed_sensor_type
         self._value = 0
-        self._attr_device_class = SensorDeviceClass.DATA_RATE
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_device_class = sensordeviceclass
+        self._attr_state_class = sensorstateclass
         super().__init__(coordinator)
 
     @property

--- a/custom_components/amplifi/sensor.py
+++ b/custom_components/amplifi/sensor.py
@@ -1,5 +1,9 @@
 """Platform for sensor integration."""
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorStateClass,
+    SensorDeviceClass,
+)
 import logging
 
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -46,6 +50,8 @@ class AmplifiWanSpeedSensor(CoordinatorEntity, SensorEntity):
         self.config_entry = config_entry
         self._speed_sensor_type = speed_sensor_type
         self._value = 0
+        self._attr_device_class = SensorDeviceClass.DATA_RATE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         super().__init__(coordinator)
 
     @property


### PR DESCRIPTION
Ignore first PR, I don't regularly work in public repos

Per https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics

Changed sensor.py to import extra objects from homeassistant.components.sensor to enable the entity to have SensorStateClass and SensorDeviceClass attributes. This allows for statistics graphs on the dashboard such as this:
![image](https://github.com/puttyman/hass-amplifi/assets/58028821/ed56c21e-2857-416f-99c9-9aba08d0a60b)

I have tried to match the style of the original code by defining variables outside the function. Please suggest changes if the formatting is not correct.