### PR TITLE
Update device_tracker.py

### DIFF
--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -86,7 +86,7 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         elif self._data is not None and "Address" in self._data:
             self._name = f"{DOMAIN}_{self._data['Address']}"
         else:
-            self._name = self.unique_id
+            self._name = f"{DOMAIN}_{self.unique_id}"
 
         self._name = re.sub("[^0-9a-zA-Z]+", "_", self._name).lower()
 


### PR DESCRIPTION
Tiny edit to standardise the naming convention of entity IDs for devices that do not provide a description, hostname, or IP address and default to MAC address.

Noticed this when we had guests over that connected iPhones with MAC address randomisation to our Guest WiFi SSID. 

See here: 
![image](https://github.com/puttyman/hass-amplifi/assets/58028821/b47279a9-f08f-4026-b0a2-31bf506cc0e1)

I've not tested this as my iPhone's IP address is available to the integration so doesn't default to the MAC address like above.

On account of not being able to test it, it is entirely possible I've got the wrong block of code. Please verify before merging.

This may be an intentional feature, in which case just close this PR.