### PR TITLE
Connected to device attribute

### DIFF
--- a/custom_components/amplifi/coordinator.py
+++ b/custom_components/amplifi/coordinator.py
@@ -73,6 +73,7 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
                             device_info = raw_wifi_devices[access_point][wifi_band][
                                 network_type
                             ][macAddr]
+                            device_info["connected_to"] = access_point
                             wifi_devices[macAddr] = device_info
 
         self._wifi_devices = wifi_devices

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -86,7 +86,7 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         elif self._data is not None and "Address" in self._data:
             self._name = f"{DOMAIN}_{self._data['Address']}"
         else:
-            self._name = self.unique_id
+            self._name = f"{DOMAIN}_{self.unique_id}"
 
         self._name = re.sub("[^0-9a-zA-Z]+", "_", self._name).lower()
 

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -131,8 +131,8 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         return None
 
     @property
-    def hostname(self):
-        """Return hostname of the device."""
+    def connected_to(self):
+        """Return mac address of the AP this device is connected to."""
         if "connected_to" in self._data:
             return self._data["connected_to"]
 

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -131,6 +131,14 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         return None
 
     @property
+    def hostname(self):
+        """Return hostname of the device."""
+        if "connected_to" in self._data:
+            return self._data["connected_to"]
+
+        return None
+
+    @property
     def extra_state_attributes(self):
         """Return extra attributes."""
         if self.coordinator.last_update_success and self._data is not None:

--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
     "@puttyman"
   ],
-  "version": "2.0.3"
+  "version": "2.0.4"
 }

--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
     "@puttyman"
   ],
-  "version": "2.0.4"
+  "version": "2.0.5"
 }

--- a/custom_components/amplifi/sensor.py
+++ b/custom_components/amplifi/sensor.py
@@ -15,7 +15,8 @@ from .const import DOMAIN, COORDINATOR, COORDINATOR_LISTENER, ENTITIES
 
 _LOGGER = logging.getLogger(__name__)
 WAN_SPEED_SENSOR_TYPES = ["download", "upload"]
-
+sensordeviceclass = SensorDeviceClass.DATA_RATE
+sensorstateclass = SensorStateClass.MEASUREMENT
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add sensors for passed config_entry in HA."""
@@ -50,8 +51,8 @@ class AmplifiWanSpeedSensor(CoordinatorEntity, SensorEntity):
         self.config_entry = config_entry
         self._speed_sensor_type = speed_sensor_type
         self._value = 0
-        self._attr_device_class = SensorDeviceClass.DATA_RATE
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_device_class = sensordeviceclass
+        self._attr_state_class = sensorstateclass
         super().__init__(coordinator)
 
     @property

--- a/custom_components/amplifi/sensor.py
+++ b/custom_components/amplifi/sensor.py
@@ -1,5 +1,9 @@
 """Platform for sensor integration."""
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorStateClass,
+    SensorDeviceClass,
+)
 import logging
 
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -46,6 +50,8 @@ class AmplifiWanSpeedSensor(CoordinatorEntity, SensorEntity):
         self.config_entry = config_entry
         self._speed_sensor_type = speed_sensor_type
         self._value = 0
+        self._attr_device_class = SensorDeviceClass.DATA_RATE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         super().__init__(coordinator)
 
     @property


### PR DESCRIPTION
Appends a "connected_to" attribute to the list of attributes for the device_tracker entity

The format of info-async.php is such that each connected device is listed beneath the MAC address of the AP is it connected to. We can simply return this as we do with other attributes. This can then be used in a markdown card with a configuration such as:
```jinja2
Mesh Point 1
{% for item in (states.device_tracker
|selectattr('entity_id', 'match', 'device_tracker.amplifi.*')
|selectattr('state', 'eq', 'home')
|map(attribute='entity_id')) %}
{% if (state_attr(item,'connected_to') == 'f0:9f:c2:xx:xx:xx') %}
* {{ item.replace('device_tracker.amplifi_','') }} 
{% endif %}
{% endfor %}
```

which gives you a result such as:
![image](https://github.com/hawksj/hass-amplifi/assets/58028821/4bdba392-31dc-4674-90ed-1db2d55cdbf8)

This is already merged in my fork and operating in my HA instance:
![image](https://github.com/puttyman/hass-amplifi/assets/58028821/9c361393-8171-4cbc-a21a-232b5af2b4ac)


This provides a solution #29 by triggering an automation based on the attributes of a device_tracker identity updating to the MAC address of the mesh point

