### PR TITLE
Make speed sensors support long-term statistics

### DIFF
--- a/custom_components/amplifi/sensor.py
+++ b/custom_components/amplifi/sensor.py
@@ -1,5 +1,9 @@
 """Platform for sensor integration."""
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorStateClass,
+    SensorDeviceClass,
+)
 import logging
 
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -11,7 +15,8 @@ from .const import DOMAIN, COORDINATOR, COORDINATOR_LISTENER, ENTITIES
 
 _LOGGER = logging.getLogger(__name__)
 WAN_SPEED_SENSOR_TYPES = ["download", "upload"]
-
+sensordeviceclass = SensorDeviceClass.DATA_RATE
+sensorstateclass = SensorStateClass.MEASUREMENT
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add sensors for passed config_entry in HA."""
@@ -46,6 +51,8 @@ class AmplifiWanSpeedSensor(CoordinatorEntity, SensorEntity):
         self.config_entry = config_entry
         self._speed_sensor_type = speed_sensor_type
         self._value = 0
+        self._attr_device_class = sensordeviceclass
+        self._attr_state_class = sensorstateclass
         super().__init__(coordinator)
 
     @property


### PR DESCRIPTION
Re-created PR #38 with correct branch

Per https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics

Changed sensor.py to import extra objects from homeassistant.components.sensor to enable the entity to have SensorStateClass and SensorDeviceClass attributes. This allows for statistics graphs on the dashboard such as this:
![image](https://github.com/puttyman/hass-amplifi/assets/58028821/ed56c21e-2857-416f-99c9-9aba08d0a60b)
![image](https://github.com/puttyman/hass-amplifi/assets/58028821/258dc6cb-8f35-42d9-933f-61e78d99e678)


I have tried to match the style of the original code by defining variables outside the function. Please suggest changes if the formatting is not correct.