### PR TITLE
Enable selecting whether new entities are enabled by default in Config Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
-# Hass Amplifi 2.0.0
+# Hass Amplifi 2.1.0
 
 **BREAKING CHANGE**
  - 2.0.0 now uses device_tracker instead of sensor for wifi presence
@@ -8,7 +8,7 @@
 A sensor hass integration that allows you to monitor devices connected to Amplifi on Wifi (LAN ports in progress).
 
 You can use this addon to perform the following automations:
-- As a presense sensor (when your mobile connects to wifi)
+- As a presense sensor (when your mobile connects to WiFi, or a specific access point)
 - Internet bandwidth usage monitor (amplifi reports data transfers on the WAN port). This integration will add 2 sensors.
 - When your TV is on/off (monitoring its wifi traffic)
 - Security (Create alerts for unknown devices connected to your wifi)

--- a/custom_components/amplifi/config_flow.py
+++ b/custom_components/amplifi/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
 from .client import AmplifiClient
-from .const import DOMAIN
+from .const import DOMAIN, CONF_ENABLE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,6 +17,7 @@ DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST, default="amplifi.lan"): str,
         vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_ENABLE, default=False): bool,
     }
 )
 

--- a/custom_components/amplifi/config_flow.py
+++ b/custom_components/amplifi/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
 from .client import AmplifiClient
-from .const import DOMAIN, CONF_ENABLE
+from .const import DOMAIN, CONF_ENABLE_NEW_DEVICES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST, default="amplifi.lan"): str,
         vol.Required(CONF_PASSWORD): str,
-        vol.Required(CONF_ENABLE, default=False): bool,
+        vol.Required(CONF_ENABLE_NEW_DEVICES, default=False): bool,
     }
 )
 

--- a/custom_components/amplifi/const.py
+++ b/custom_components/amplifi/const.py
@@ -4,4 +4,5 @@ DOMAIN = "amplifi"
 COORDINATOR = "coordinator"
 ENTITIES = "entities"
 COORDINATOR_LISTENER = "coordinator-listener"
+CONF_ENABLE = "enable"
 SCAN_INTERVAL = 10

--- a/custom_components/amplifi/const.py
+++ b/custom_components/amplifi/const.py
@@ -4,5 +4,5 @@ DOMAIN = "amplifi"
 COORDINATOR = "coordinator"
 ENTITIES = "entities"
 COORDINATOR_LISTENER = "coordinator-listener"
-CONF_ENABLE = "enable"
+CONF_ENABLE_NEW_DEVICES = "enable_new_devices"
 SCAN_INTERVAL = 10

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.core import callback
-from .const import DOMAIN, COORDINATOR, COORDINATOR_LISTENER, ENTITIES
+from .const import DOMAIN, COORDINATOR, COORDINATOR_LISTENER, ENTITIES, CONF_ENABLE
 from .coordinator import AmplifiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -144,6 +144,11 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         if self.coordinator.last_update_success and self._data is not None:
             return {**self._data, "last_seen": datetime.now().isoformat()}
         return {}
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return hass.data[CONF_ENABLE]
 
     def update(self):
         _LOGGER.debug(f"entity={self.unique_id} update() was called")

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.core import callback
-from .const import DOMAIN, COORDINATOR, COORDINATOR_LISTENER, ENTITIES, CONF_ENABLE
+from .const import DOMAIN, COORDINATOR, COORDINATOR_LISTENER, ENTITIES, CONF_ENABLE_NEW_DEVICES
 from .coordinator import AmplifiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -148,7 +148,7 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
-        if self.config_entry.data[CONF_ENABLE]:
+        if self.config_entry.data[CONF_ENABLE_NEW_DEVICES]:
             return True
         
         return False

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -148,7 +148,10 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
-        return CONF_ENABLE
+        if self.config_entry.data[CONF_ENABLE]:
+            return True
+        
+        return False
 
     def update(self):
         _LOGGER.debug(f"entity={self.unique_id} update() was called")

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -148,7 +148,7 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
-        return hass.data[CONF_ENABLE]
+        return CONF_ENABLE
 
     def update(self):
         _LOGGER.debug(f"entity={self.unique_id} update() was called")

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -148,7 +148,7 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
-        if self.config_entry.data[CONF_ENABLE_NEW_DEVICES]:
+        if self.config_entry.data.get(CONF_ENABLE_NEW_DEVICES, False):
             return True
         
         return False

--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
     "@puttyman"
   ],
-  "version": "2.0.5"
+  "version": "2.1.0"
 }

--- a/custom_components/amplifi/strings.json
+++ b/custom_components/amplifi/strings.json
@@ -5,7 +5,7 @@
         "title": "AmpliFi Login",
         "description": "Enter the admin details of your AmpliFi router",
         "data": {
-          "host": [%key:common::config_flow::data::host%]",
+          "host": "[%key:common::config_flow::data::host%]",
           "password": "[%key:common::config_flow::data::password%]",
           "enable": "[%key:common::config_flow::data::enable%]",
           "scan_interval": "Update interval in seconds"

--- a/custom_components/amplifi/strings.json
+++ b/custom_components/amplifi/strings.json
@@ -7,7 +7,7 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "enable": "[%key:common::config_flow::data::enable%]",
+          "enable_new_devices": "[%key:common::config_flow::data::enable_new_devices%]",
           "scan_interval": "Update interval in seconds"
         }
       }

--- a/custom_components/amplifi/strings.json
+++ b/custom_components/amplifi/strings.json
@@ -2,9 +2,12 @@
   "config": {
     "step": {
       "user": {
+        "title": "AmpliFi Login",
+        "description": "Enter the admin details of your AmpliFi router",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
+          "host": [%key:common::config_flow::data::host%]",
           "password": "[%key:common::config_flow::data::password%]",
+          "enable": "[%key:common::config_flow::data::enable%]",
           "scan_interval": "Update interval in seconds"
         }
       }

--- a/custom_components/amplifi/translations/en.json
+++ b/custom_components/amplifi/translations/en.json
@@ -10,9 +10,13 @@
     },
     "step": {
       "user": {
+        "title": "AmpliFi Login",
+        "description": "Enter the admin details of your AmpliFi router",
         "data": {
-          "host": "Host",
-          "password": "Password"
+          "host": "AmpliFi Router Hostname/IP Address",
+          "password": "AmpliFi Router Admin Password",
+          "enable": "Enable Newly Discovered Devices",
+          "scan_interval": "Update interval in seconds"
         }
       }
     }

--- a/custom_components/amplifi/translations/en.json
+++ b/custom_components/amplifi/translations/en.json
@@ -15,7 +15,7 @@
         "data": {
           "host": "AmpliFi Router Hostname/IP Address",
           "password": "AmpliFi Router Admin Password",
-          "enable": "Enable Newly Discovered Devices",
+          "enable_new_devices": "Enable Newly Discovered Devices",
           "scan_interval": "Update interval in seconds"
         }
       }


### PR DESCRIPTION
This is the largest change I've made to date. It creates resolves #27 which was initially solved with PR #31 but was later reverted in PR #33 due to #32. That has been fixed in this PR and I have re-added the integration many times with the tickbox checked and unchecked and I have had no log errors.

This change adds a new tickbox during the config flow which allows the user to select whether they would like new entities to be automatically enabled when discovered. I added this as personally, I prefer entities to be automatically enabled but enabling it by default for all instances and not being able to change it without modifying the integration code isn't ideal for many users and could cause the database to grow too large in some installations as stated in https://developers.home-assistant.io/docs/core/entity/#generic-properties.
![image](https://github.com/puttyman/hass-amplifi/assets/58028821/5d4f0af2-8397-48c7-be00-37e21216a9a7)

This PR also makes minor changes to the translations files to make the config flow look nicer and describe the fields better.

I had to learn a lot to make this work and I think it looks fine but I would appreciate someone with more experience to give me the thumbs up that it looks okay.