### PR TITLE
Return better friendly names for connected devices

### DIFF
--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
     "@puttyman"
   ],
-  "version": "2.1.0"
+  "version": "2.1.1"
 }

--- a/custom_components/amplifi/sensor.py
+++ b/custom_components/amplifi/sensor.py
@@ -55,14 +55,16 @@ class AmplifiWanSpeedSensor(CoordinatorEntity, SensorEntity):
         self._attr_state_class = sensorstateclass
         super().__init__(coordinator)
 
+        self.entity_id = f'sensor.{self._name}'
+
     @property
     def available(self):
         """Return if sensor is available."""
         return True
-    
+
     @property
     def name(self) -> str | None:
-        return self._name
+        return f"Amplifi WAN {self._speed_sensor_type.title()} Speed"
 
     @property
     def state(self):


### PR DESCRIPTION
It has always bothered me a little that the default friendly names for the entities has been the unique ID instead of the configured name within the Amplifi app:

![image](https://github.com/puttyman/hass-amplifi/assets/3691326/21a64c9a-a7ca-4f09-a126-995e60b5cd15)

This change extracts the user-defined name and returns that as the 'friendly name' within HA while keep the entity_id as-is:
![image](https://github.com/puttyman/hass-amplifi/assets/3691326/aff431a0-fa1d-47a5-bf96-829f48f947a6)

In addition, there is an extension to tease out more information for Ethernet connected devices and return that as the friendly name as well:

![image](https://github.com/puttyman/hass-amplifi/assets/3691326/cd74b085-fdb9-401c-a409-2df3a1e1f494)

For completions sake, the WAN upload/download speed sensor has been adjusted too:
![image](https://github.com/puttyman/hass-amplifi/assets/3691326/eedb6c37-800e-4d2c-b043-705c7548aa1b)

