### PR TITLE
master: 2.1.1 changes

### DIFF
--- a/custom_components/amplifi/coordinator.py
+++ b/custom_components/amplifi/coordinator.py
@@ -49,6 +49,7 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
         super().async_add_listener(self.extract_wifi_devices)
         super().async_add_listener(self.extract_ethernet_ports)
+        super().async_add_listener(self.extract_ethernet_devices)
         super().async_add_listener(self.extract_wan_speeds)
 
     async def _async_update_data(self):
@@ -89,14 +90,24 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
         self._ethernet_ports = self.data[ETHERNET_PORTS_IDX][router_mac_addr]
         _LOGGER.debug(f"ports={self.ethernet_ports}")
 
-        # Try get additional device info for connected ethernet ports
+    def extract_ethernet_devices(self):
+        """Try get additional device info for connected ethernet ports."""
+        if self.data is None:
+            return
+        router_mac_addr = self.get_router_mac_addr()
+
+        ethernet_devices = {}
         raw_devices_info = self.data[DEVICES_INFO_IDX]
         raw_device_to_eth_index = self.data[ETHERNET_PORT_TO_DEVICE_IDX][router_mac_addr]
 
         if raw_device_to_eth_index and raw_devices_info:
                 for device in raw_device_to_eth_index:
+                    device_info = raw_devices_info[device]
                     port = raw_device_to_eth_index[device]
-                    self._ethernet_devices[port] = raw_devices_info[device]
+                    device_info["connected_to_port"] = port
+                    ethernet_devices[device] = device_info
+
+        self._ethernet_devices = ethernet_devices
 
         _LOGGER.debug(f"ethernet_devices={self._ethernet_devices}")
 

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -302,6 +302,17 @@ class AmplifiEthernetDeviceTracker(CoordinatorEntity, ScannerEntity):
             return {**self._data, "last_seen": datetime.now().isoformat()}
         return {}
 
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        if self._is_device:
+            if self.config_entry.data.get(CONF_ENABLE_NEW_DEVICES, False):
+                return True
+            else:
+                return False
+        else:
+            return True
+
     def update(self):
         _LOGGER.debug(f"entity={self.unique_id} update() was called")
         self._handle_coordinator_update()

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -291,6 +291,11 @@ class AmplifiEthernetDeviceTracker(CoordinatorEntity, ScannerEntity):
             return "mdi:ethernet"
 
     @property
+    def mac_address(self):
+        """Return the mac address of the device."""
+        return self.unique_id
+
+    @property
     def extra_state_attributes(self):
         """Return extra attributes."""
         if self.coordinator.last_update_success and self._data is not None:

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -37,6 +37,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     ]
                 )
 
+        is_device = False
         for port in range(0, 5):
             port_unique_id = f"{DOMAIN}_eth_port_{port}"
             if port_unique_id not in hass.data[DOMAIN][config_entry.entry_id][ENTITIES]:
@@ -46,6 +47,21 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                             coordinator,
                             port,
                             config_entry,
+                            is_device,
+                        )
+                    ]
+                )
+
+        is_device = True
+        for mac_addr in coordinator.ethernet_devices:
+            if mac_addr not in hass.data[DOMAIN][config_entry.entry_id][ENTITIES]:
+                async_add_entities(
+                    [
+                        AmplifiEthernetDeviceTracker(
+                            coordinator,
+                            mac_addr,
+                            config_entry,
+                            is_device,
                         )
                     ]
                 )
@@ -202,32 +218,47 @@ class AmplifiEthernetDeviceTracker(CoordinatorEntity, ScannerEntity):
     _device_info = {}
     _connected = True
     _is_wan = False
+    _is_device = False
     unique_id = None
 
-    def __init__(self, coordinator: AmplifiDataUpdateCoordinator, port, config_entry):
+    def __init__(self, coordinator: AmplifiDataUpdateCoordinator, identifier, config_entry, is_device):
         """Initialize amplifi ethernet device tracker."""
         super().__init__(coordinator)
-        self._port = port
-        self._data_key = f"eth-{port}"
-        self.unique_id = f"{DOMAIN}_eth_port_{self._port}"
-        self._data = coordinator.ethernet_ports[f"{self._data_key}"]
-        self.config_entry = config_entry
+        if is_device:
+            self._mac_addr = identifier
+            self._data_key = self._mac_addr
+            self.unique_id = self._mac_addr
+            self._data = coordinator.ethernet_devices[f"{self._data_key}"]
+            self.config_entry = config_entry
 
-        # Optional device info for connected Ethernet ports
-        if self._port in coordinator.ethernet_devices:
-            self._device_info = coordinator.ethernet_devices[self._port]
+            # Optional device info for connected Ethernet ports
+            if self._mac_addr in coordinator.ethernet_devices:
+                self._device_info = coordinator.ethernet_devices[self._mac_addr]
 
-        if self._device_info is not None and "description" in self._device_info:
-            self._description = self._device_info['description']
-        elif self._device_info is not None and "host_name" in self._device_info:
-            self._description = self._device_info['host_name']
-        elif self._device_info is not None and "ip" in self._device_info:
-            self._description = self._device_info['ip']
+            if self._device_info is not None and "description" in self._device_info:
+                self._name = f"{DOMAIN}_{self._data['description']}"
+                self._description = self._device_info['description']
+            elif self._device_info is not None and "host_name" in self._device_info:
+                self._name = f"{DOMAIN}_{self._data['host_name']}"
+                self._description = self._device_info['host_name']
+            elif self._device_info is not None and "ip" in self._device_info:
+                self._name = f"{DOMAIN}_{self._data['ip']}"
+                self._description = self._device_info['ip']
+            else:
+                self._name = f"{DOMAIN}_{self._mac_addr}"
+                self._description = self._mac_addr
+
         else:
+            self._port = identifier
+            self._data_key = f"eth-{self._port}"
+            self.unique_id = f"{DOMAIN}_eth_port_{self._port}"
+            self._data = coordinator.ethernet_ports[f"{self._data_key}"]
+            self.config_entry = config_entry
             self._description = f"Ethernet Port {self._port}"
+            self._name = self.unique_id
 
-        self._name = self.unique_id
-        
+        self._is_device = is_device
+
         # Override the entity_id so we can provide a better friendly name
         self.entity_id = f'device_tracker.{self._name}'
 
@@ -246,12 +277,18 @@ class AmplifiEthernetDeviceTracker(CoordinatorEntity, ScannerEntity):
 
     @property
     def is_connected(self):
-        return "link" in self._data and self._data["link"] == True
+        if self._is_device:
+            return self._connected
+        else:
+            return "link" in self._data and self._data["link"] == True
 
     @property
     def icon(self):
         """Return the icon."""
-        return "mdi:ethernet"
+        if self._is_device:
+            return "mdi:lan-connect"
+        else:
+            return "mdi:ethernet"
 
     @property
     def extra_state_attributes(self):
@@ -278,8 +315,10 @@ class AmplifiEthernetDeviceTracker(CoordinatorEntity, ScannerEntity):
 
     @callback
     def _handle_coordinator_update(self):
-        if self._data_key in self.coordinator.ethernet_ports:
+        if not self._is_device and self._data_key in self.coordinator.ethernet_ports:
             self._data = self.coordinator.ethernet_ports[self._data_key]
+        elif self._is_device and self._data_key in self.coordinator.ethernet_devices:
+            self._data = self.coordinator.ethernet_devices[self._data_key]
 
         _LOGGER.debug(
             f"entity={self.unique_id} was updated via _handle_coordinator_update"

--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
     "@puttyman"
   ],
-  "version": "2.1.0"
+  "version": "2.1.1"
 }

--- a/custom_components/amplifi/sensor.py
+++ b/custom_components/amplifi/sensor.py
@@ -55,14 +55,16 @@ class AmplifiWanSpeedSensor(CoordinatorEntity, SensorEntity):
         self._attr_state_class = sensorstateclass
         super().__init__(coordinator)
 
+        self.entity_id = f'sensor.{self._name}'
+
     @property
     def available(self):
         """Return if sensor is available."""
         return True
-    
+
     @property
     def name(self) -> str | None:
-        return self._name
+        return f"Amplifi WAN {self._speed_sensor_type.title()} Speed"
 
     @property
     def state(self):


### PR DESCRIPTION
This PR merges all the changes for providing better friendly names to entities and providing Ethernet device tracker entities into the master branch.

The changes that are suggested in this PR are pushed to the ```dev``` branch and as of PR creation, tagged and released as v2.1.1-beta.2

Device Tracker entities and speed sensor entities are now given proper (capitalized!) names that reflect how they appear in the AmpliFi app and creates new entities for devices that are connected via Ethernet (if the config entry boolean is enabled):
![image](https://github.com/puttyman/hass-amplifi/assets/58028821/bbea1f0d-e2e2-4093-a163-cbb176e6309a)

These new entities report their upstream Ethernet port, their IP address, hostname and more:
![image](https://github.com/puttyman/hass-amplifi/assets/58028821/1f9a98b0-e70d-42e2-8a23-8a190049d1b6)
