### PR TITLE
2.1.2 bugfixes

### DIFF
--- a/custom_components/amplifi/coordinator.py
+++ b/custom_components/amplifi/coordinator.py
@@ -111,6 +111,9 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
             self._ethernet_devices = ethernet_devices
     
             _LOGGER.debug(f"ethernet_devices={self._ethernet_devices}")
+        else:
+            _LOGGER.debug(f"No ethernet devices found")
+            return
 
     def extract_wan_speeds(self):
         if self.data is None:

--- a/custom_components/amplifi/coordinator.py
+++ b/custom_components/amplifi/coordinator.py
@@ -96,20 +96,21 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
             return
         router_mac_addr = self.get_router_mac_addr()
 
-        ethernet_devices = {}
-        raw_devices_info = self.data[DEVICES_INFO_IDX]
-        raw_device_to_eth_index = self.data[ETHERNET_PORT_TO_DEVICE_IDX][router_mac_addr]
-
-        if raw_device_to_eth_index and raw_devices_info:
-                for device in raw_device_to_eth_index:
-                    device_info = raw_devices_info[device]
-                    port = raw_device_to_eth_index[device]
-                    device_info["connected_to_port"] = port
-                    ethernet_devices[device] = device_info
-
-        self._ethernet_devices = ethernet_devices
-
-        _LOGGER.debug(f"ethernet_devices={self._ethernet_devices}")
+        if router_mac_addr in self.data[ETHERNET_PORT_TO_DEVICE_IDX]:
+            ethernet_devices = {}
+            raw_devices_info = self.data[DEVICES_INFO_IDX]
+            raw_device_to_eth_index = self.data[ETHERNET_PORT_TO_DEVICE_IDX][router_mac_addr]
+    
+            if raw_device_to_eth_index and raw_devices_info:
+                    for device in raw_device_to_eth_index:
+                        device_info = raw_devices_info[device]
+                        port = raw_device_to_eth_index[device]
+                        device_info["connected_to_port"] = port
+                        ethernet_devices[device] = device_info
+    
+            self._ethernet_devices = ethernet_devices
+    
+            _LOGGER.debug(f"ethernet_devices={self._ethernet_devices}")
 
     def extract_wan_speeds(self):
         if self.data is None:

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -107,6 +107,7 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
             self._description = self._data['Address']
         else:
             self._name = f"{DOMAIN}_{self.unique_id}"
+            self._description = self.unique_id.upper()
 
         self._name = re.sub("[^0-9a-zA-Z]+", "_", self._name).lower()
         # Override the entity_id so we can provide a better friendly name
@@ -293,7 +294,8 @@ class AmplifiEthernetDeviceTracker(CoordinatorEntity, ScannerEntity):
     @property
     def mac_address(self):
         """Return the mac address of the device."""
-        return self.unique_id
+        if self._is_device:
+            return self.unique_id
 
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
This PR is smaller than it appears. It adds a check when trying to get the list of Ethernet devices to ensure that the key exists before trying to access it.

It also gives WiFi devices that have no hostname/IP address a better friendly name by not including the amplifi_ prefix in the friendly name and capitalising the letters.

The last fix is preventing the Ethernet Port device trackers from getting a MAC attribute which was erroneously included for Ethernet Devices but is not applicable for Ports.

This resolves #55 